### PR TITLE
Add optional timeout for git network commands

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -2,19 +2,29 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Repo is the git repo and information we need to know about it
 type Repo struct {
-	path string
+	path    string
+	timeout *time.Duration
 }
 
 // NewRepo creates a new Repo for the given path
 func NewRepo(path string) *Repo {
 	return &Repo{path: path}
+}
+
+// WithTimeout can be used to set a timeout on the networked commands like
+// "ShallowClone" and "CheckoutCommitOnly". Set to nil to disable timeouts
+func (r *Repo) WithTimeout(timeout *time.Duration) *Repo {
+	r.timeout = timeout
+	return r
 }
 
 // CurrentBranch returns the current git branch if it exists, otherwise it
@@ -28,16 +38,6 @@ func (r *Repo) CurrentBranch() (string, error) {
 func (r *Repo) CommitHash() (string, error) {
 	out, err := r.execute("rev-parse", "HEAD")
 	return strings.TrimSpace(out), err
-}
-
-func (r *Repo) execute(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	if r.path != "" {
-		cmd.Dir = r.path
-	}
-
-	out, err := cmd.CombinedOutput()
-	return string(out), err
 }
 
 // ShallowClone does a shallow clone of the repo to the filepath given.
@@ -76,4 +76,28 @@ func (r *Repo) CheckoutCommitOnly(repo string, commitSHA string) (string, error)
 		}
 	}
 	return buf.String(), nil
+}
+
+func (r *Repo) execute(args ...string) (string, error) {
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	if r.timeout != nil {
+		ctx, cancel = context.WithTimeout(context.Background(), *r.timeout)
+		defer cancel()
+	} else {
+		ctx = context.TODO()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if r.path != "" {
+		cmd.Dir = r.path
+	}
+
+	out, err := cmd.CombinedOutput()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return string(out), ctx.Err()
+	}
+	return string(out), err
 }

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -1,0 +1,22 @@
+package git
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeout(t *testing.T) {
+	dir, err := ioutil.TempDir("", "timeout-test")
+	assert.Nil(t, err)
+	defer func() { os.RemoveAll(dir) }()
+
+	timeout := 300 * time.Millisecond
+	r := NewRepo(dir).WithTimeout(&timeout)
+	_, err = r.ShallowClone("https://github.com/torvalds/linux.git")
+	assert.Equal(t, err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
This should help us set reasonable timeout on git clone or git checkout from FETCH_HEAD so that we don't stall for several hours if we hit the malloc issue.