### PR TITLE
Add support for opening URL on linux platforms

### DIFF
--- a/cmd/jira/main.go
+++ b/cmd/jira/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
+
+	"github.com/jonstacks/tools/pkg/utils"
 
 	docopt "github.com/docopt/docopt-go"
 	"github.com/jonstacks/tools/pkg/git"
@@ -50,7 +51,5 @@ Options:
 
 	url := issue.URL(config.Host)
 
-	openCmd := exec.Command("open", url)
-	err = openCmd.Run()
-	handleError(err)
+	handleError(utils.OpenInBrowser(url))
 }

--- a/pkg/utils/open.go
+++ b/pkg/utils/open.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenInBrowser opens the given URL in the browser by shelling out to the
+// system command for opening the browser
+func OpenInBrowser(url string) error {
+	var openCmd string
+
+	switch runtime.GOOS {
+	case "darwin":
+		openCmd = "open"
+	case "linux":
+		openCmd = "xdg-open"
+	}
+
+	open := exec.Command(openCmd, url)
+	return open.Run()
+}


### PR DESCRIPTION
Right now, this command only works on mac using the `open` command. This PR adds support for linux systems using the `xdg-open` command.