### PR TITLE
Add command for jira description

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13']
+        go: ['1.16']
     name: go-${{ matrix.go }}
     steps:
       - uses: actions/checkout@v2

--- a/cmd/jira/README.md
+++ b/cmd/jira/README.md
@@ -2,15 +2,24 @@
 
 A JIRA command line utility for easily opening your issues from the terminal.
 
+- [Usage](#usage)
+  - [Config](#config)
+- [Basic](#basic)
+- [Print Description](#print-description)
 ## Usage
 
+### Config
 Create the following file ~/.jira/config.json:
 
   ```json
   {
-    "host": "https://myjira.com"
+    "host": "https://myjira.com",
+    "user_email": "my.email@domain.com",
+    "api_token": "abc123"
   }
   ```
+
+## Basic
 
 Now, if you name your branch after the current issue you are working on, you
 can simply do:
@@ -24,4 +33,20 @@ open up a different issue, you can also do that by specifying it like so:
 
 ```sh
 $ jira ABC-1234
+```
+
+## Print Description
+
+You may also wish to print the description in markdown format for easily including
+in a GH issue or PR. This sub command requires a user email and API token in your
+config.
+
+```sh
+$ jira description
+```
+
+or
+
+```sh
+$ jira description ABC-1234
 ```

--- a/cmd/jira/jira-description.template
+++ b/cmd/jira/jira-description.template
@@ -1,0 +1,5 @@
+[JIRA Link]({{ .Config.Host }}/browse/{{ .Issue.Key }})
+
+## Description
+
+{{ .Issue.Fields.Description }}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/jonstacks/tools
 
-go 1.13
+go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docopt/docopt-go v0.0.0-20160216232012-784ddc588536
 	github.com/mitchellh/go-homedir v1.0.0
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20160216232012-784ddc588536 h1:rHnpq7uNlix5l7tWZ55iJcHHrxCPnOVF4FGb7qOT2Jc=
 github.com/docopt/docopt-go v0.0.0-20160216232012-784ddc588536/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -1,0 +1,69 @@
+package jira
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type ClientOpts struct {
+	BaseURL   string
+	UserEmail string
+	APIToken  string
+	Timeout   time.Duration
+}
+
+type Client struct {
+	opts   *ClientOpts
+	client *http.Client
+}
+
+func NewClient(opts *ClientOpts) *Client {
+	client := http.Client{
+		Timeout: opts.Timeout,
+	}
+	return &Client{
+		opts:   opts,
+		client: &client,
+	}
+}
+
+func (c *Client) GetIssue(key string) (*Issue, error) {
+	url := fmt.Sprintf("issue/%s", key)
+	req, err := c.request("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	issue := &Issue{}
+	err = json.Unmarshal(body, issue)
+	return issue, err
+}
+
+func (c *Client) request(method string, url string, body io.Reader) (*http.Request, error) {
+	url = fmt.Sprintf("%s/rest/api/2/%s", c.opts.BaseURL, url)
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	authorization := base64.StdEncoding.EncodeToString(
+		[]byte(fmt.Sprintf("%s:%s", c.opts.UserEmail, c.opts.APIToken)),
+	)
+	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", authorization))
+	req.Header.Add("Content-Type", "application/json")
+
+	return req, err
+}

--- a/pkg/jira/config.go
+++ b/pkg/jira/config.go
@@ -3,13 +3,17 @@ package jira
 import (
 	"encoding/json"
 	"io/ioutil"
+	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 )
 
 // Config struct for storing JSON data file
 type Config struct {
-	Host string
+	Host      string
+	UserEmail string `json:"user_email"`
+	APIToken  string `json:"api_token"`
+	Timeout   *time.Duration
 }
 
 // GetConfig reads the config file from the possible locations and then

--- a/pkg/jira/issue.go
+++ b/pkg/jira/issue.go
@@ -9,7 +9,13 @@ var issueRegex = regexp.MustCompile(`\w+\-\d+`)
 
 // Issue is a struct representing a JIRA issue.
 type Issue struct {
-	key string
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Self   string `json:"self"`
+	Fields struct {
+		Description string `json:"description"`
+		Summary     string `json:"summmary"`
+	} `json:"fields"`
 }
 
 // ParseIssue tries to parse a JIRA key from a string. If it
@@ -19,16 +25,16 @@ func ParseIssue(key string) (*Issue, error) {
 	match := issueRegex.FindString(key)
 	if match == "" {
 		// No match was found
-		return nil, fmt.Errorf("Unable to parse Issue key from '%s'", key)
+		return nil, fmt.Errorf("unable to parse Issue key from '%s'", key)
 	}
-	return &Issue{match}, nil
+	return &Issue{Key: match}, nil
 }
 
 func (i Issue) String() string {
-	return i.key
+	return i.Key
 }
 
 // URL returns the URL for the JIRA issue
 func (i Issue) URL(h string) string {
-	return fmt.Sprintf("%s/browse/%s", h, i.key)
+	return fmt.Sprintf("%s/browse/%s", h, i.Key)
 }


### PR DESCRIPTION
Adds a new command `jira description` which prints out a markdown formatted description of the JIRA issue for pasting in pages.